### PR TITLE
Fix multibyte string corruption by using UTF-8 byte length

### DIFF
--- a/src/CdrWriter.test.ts
+++ b/src/CdrWriter.test.ts
@@ -1,5 +1,5 @@
 import { CdrReader } from "./CdrReader";
-import { CdrWriter } from "./CdrWriter";
+import { CdrWriter, stringLengthUtf8 } from "./CdrWriter";
 import { EncapsulationKind } from "./EncapsulationKind";
 
 const tf2_msg__TFMessage =
@@ -150,6 +150,26 @@ describe("CdrWriter", () => {
     expect(Array.from(reader.uint64Array().values())).toEqual([0n, 18446744073709551615n, 3n]);
   });
 
+  it.each(["", "abc", "こんにちは", "Ünïçödé", "🎉🚀", "mixed ascii と 日本語 と 🎉"])(
+    "round trips multibyte string %p",
+    (value) => {
+      const writer = new CdrWriter();
+      writer.string(value);
+
+      const utf8ByteLength = stringLengthUtf8(value);
+      const data = writer.data;
+      // 4 byte encapsulation header + 4 byte length prefix + UTF-8 bytes + null terminator
+      expect(data.byteLength).toEqual(4 + 4 + utf8ByteLength + 1);
+      // The length prefix must count UTF-8 bytes, not UTF-16 code units
+      expect(new DataView(data.buffer, data.byteOffset).getUint32(4, true)).toEqual(
+        utf8ByteLength + 1,
+      );
+
+      const reader = new CdrReader(data);
+      expect(reader.string()).toEqual(value);
+    },
+  );
+
   it("writes parameter lists", () => {
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
     writer.uint8(0x42);
@@ -212,6 +232,30 @@ describe("CdrWriter", () => {
       "05400800" +  // uint32
       "0f00000000000000" //uint64
     );
+  });
+});
+
+describe("stringLengthUtf8", () => {
+  it.each<[string, number]>([
+    ["", 0],
+    ["abc", 3],
+    ["\u007f", 1], // U+007F: largest 1-byte code point
+    ["\u0080", 2], // U+0080: smallest 2-byte code point
+    ["Ünïçödé", 12], // 5 two-byte code points + 2 ascii
+    ["こんにちは", 15], // 5 three-byte code points
+    ["\uffff", 3], // U+FFFF: largest 3-byte code point in the BMP
+    ["🎉", 4], // surrogate pair -> 4 bytes
+    ["🎉🚀", 8],
+  ])("counts UTF-8 bytes of %p as %i", (value, expected) => {
+    expect(stringLengthUtf8(value)).toEqual(expected);
+    // Must agree with the platform UTF-8 encoder
+    expect(stringLengthUtf8(value)).toEqual(new TextEncoder().encode(value).length);
+  });
+
+  it("matches the TextEncoder byte length for lone surrogates", () => {
+    // A lone high surrogate is encoded as U+FFFD (3 bytes) by TextEncoder
+    const loneSurrogate = "\ud83c";
+    expect(stringLengthUtf8(loneSurrogate)).toEqual(new TextEncoder().encode(loneSurrogate).length);
   });
 });
 

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -12,6 +12,35 @@ export type CdrWriterOpts = {
 
 const textEncoder = new TextEncoder();
 
+/**
+ * Returns the UTF-8 byte length of a string. `String.prototype.length` counts
+ * UTF-16 code units, which undercounts non-ASCII content and would corrupt the
+ * CDR length prefix, so the byte length is computed explicitly.
+ */
+export function stringLengthUtf8(str: string): number {
+  let byteLength = 0;
+  for (let i = 0; i < str.length; i++) {
+    const codeUnit = str.charCodeAt(i);
+    if (codeUnit <= 0x7f) {
+      byteLength += 1;
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2;
+    } else if (0xd800 <= codeUnit && codeUnit <= 0xdbff) {
+      // Surrogate pair -> one 4-byte code point; a lone surrogate becomes U+FFFD (3 bytes)
+      const nextCodeUnit = str.charCodeAt(i + 1);
+      if (0xdc00 <= nextCodeUnit && nextCodeUnit <= 0xdfff) {
+        byteLength += 4;
+        i++;
+      } else {
+        byteLength += 3;
+      }
+    } else {
+      byteLength += 3;
+    }
+  }
+  return byteLength;
+}
+
 export class CdrWriter {
   static DEFAULT_CAPACITY = 16;
   static BUFFER_COPY_THRESHOLD = 10;
@@ -163,7 +192,7 @@ export class CdrWriter {
 
   // writeLength optional because it could already be included in a header
   string(value: string, writeLength = true): this {
-    const strlen = value.length;
+    const strlen = stringLengthUtf8(value);
     if (writeLength) {
       this.uint32(strlen + 1); // Add one for the null terminator
     }


### PR DESCRIPTION
## Summary
`CdrWriter.string()` sized the CDR length prefix with `String.prototype.length` (UTF-16 code units) instead of the UTF-8 byte length. For non-ASCII content (CJK characters, emoji, etc.) this undercounts the prefix and makes `TextEncoder.encodeInto` truncate the output, corrupting the serialized string (e.g. "こんにちは" -> "こ\x00\x00").

## Changes
- Add a `stringLengthUtf8()` helper that computes the UTF-8 byte length.
- Use it in `CdrWriter.string()` for the length prefix and write buffer sizing, keeping the existing `encodeInto` fast path.
- Add round-trip tests for multibyte strings and unit tests for the helper.

## Context
Reported in lichtblick-suite/lichtblick#1103.

## Testing
- `yarn test` (121 passed)
- `yarn lint:ci`
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string serialization to correctly handle multibyte characters (Japanese, emoji, etc.) by properly accounting for UTF-8 byte lengths instead of character counts.

* **Tests**
  * Added test coverage validating UTF-8 string serialization, including round-trip testing with mixed ASCII and multibyte characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->